### PR TITLE
Use yargs strict mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,6 @@
 require('yargs')
 	.commandDir('commands')
 	.demandCommand()
+	.strict()
 	.help()
 	.argv;


### PR DESCRIPTION
Unrecognized commands, e.g. `verify-config` instead of `validate-config`, will be reported as an error by yargs. This should make for a much nicer developer experience when using the CLI, as currently you don't receive any output when you give it the name of a command that doesn't exist.

Resolves #54.