### PR TITLE
CPP-298 Wait for approval on CircleCI builds from nori and renovate PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,13 @@
+references:
+
+  filters_only_renovate_nori: &filters_only_renovate_nori
+    branches:
+      only: /(^renovate-.*|^nori\/.*)/
+
+  filters_ignore_renovate_nori: &filters_ignore_renovate_nori
+    branches:
+      ignore: /(^renovate-.*|^nori\/.*|^master)/
+
 version: 2
 
 jobs:
@@ -30,3 +40,22 @@ jobs:
 
       - store_artifacts:
           path: test-results/
+
+workflows:
+  version: 2
+
+  build:
+    jobs:
+      - build:
+          filters:
+            <<: *filters_ignore_renovate_nori
+
+  renovate-nori-build:
+    jobs:
+      - waiting-for-approval:
+          type: approval
+          filters:
+            <<: *filters_only_renovate_nori
+      - build:
+          requires:
+            - waiting-for-approval


### PR DESCRIPTION
Renovate and Nori create many PRs which queue loads of builds in CircleCI blocking other PRs across the entire organisation from building, as a solution we are having PRs created by Renovate and Nori pause from building until approved. <br/><br/>This PR was created using a nori script ?<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._