### PR TITLE
CPP-442 Upgrade GitHub repos from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
 
   filters_ignore_renovate_nori: &filters_ignore_renovate_nori
     branches:
-      ignore: /(^renovate-.*|^nori\/.*|^master)/
+      ignore: /(^renovate-.*|^nori\/.*|^main)/
 
 version: 2
 


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)<br/><br/>As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive. This PR is for making those changes. <br/><br/>This PR was created using a nori script<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._